### PR TITLE
Add ability for HTTP Port to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The adapter requires the following environment variables to be defined before yo
 | MATTERMOST\_USER | Yes | The Mattermost user account name e.g. _hubot@yourcompany.com_ |
 | MATTERMOST\_PASSWORD | Yes | The password of the user e.g. _s3cr3tP@ssw0rd!_ |
 | MATTERMOST\_WSS\_PORT | No | Overrides the default port `443` for  websocket (`wss://`) connections |
+| MATTERMOST\_HTTP\_PORT | No | Overrides the default port (`80` or `443`) for `http://` or `https://` connections |
 | MATTERMOST\_TLS\_VERIFY | No | (default: true) set to 'false' to allow connections when certs can not be verified (ex: self-signed, internal CA, ... - MITM risks) |
 | MATTERMOST\_USE\_TLS | No | (default: true) set to 'false' to switch to http/ws protocols |
 | MATTERMOST\_LOG\_LEVEL | No | (default: info) set log level (also: debug, ...) |

--- a/src/matteruser.coffee
+++ b/src/matteruser.coffee
@@ -10,6 +10,7 @@ class Matteruser extends Adapter
         mmPassword = process.env.MATTERMOST_PASSWORD
         mmGroup = process.env.MATTERMOST_GROUP
         mmWSSPort = process.env.MATTERMOST_WSS_PORT or '443'
+        mmHTTPPort = process.env.MATTERMOST_HTTP_PORT or null
 
         unless mmHost?
             @robot.logger.emergency "MATTERMOST_HOST is required"
@@ -24,7 +25,7 @@ class Matteruser extends Adapter
             @robot.logger.emergency "MATTERMOST_GROUP is required"
             process.exit 1
 
-        @client = new MatterMostClient mmHost, mmGroup, mmUser, mmPassword, {wssPort: mmWSSPort, pingInterval: 30000}
+        @client = new MatterMostClient mmHost, mmGroup, mmUser, mmPassword, {wssPort: mmWSSPort, httpPort: mmHTTPPort, pingInterval: 30000}
 
         @client.on 'open', @.open
         @client.on 'loggedIn', @.loggedIn


### PR DESCRIPTION
This adds the ability to set MATTERMOST_HTTP_PORT as an option for those who have a different https port.  Note that in most cases HTTP_PORT and WSS_PORT are probably the same, but I chose to break it out so that it had flexibility in the future.

This is in reference to resolving issue #10 