### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Follow the [Mattermost install guides](https://docs.mattermost.com/guides/admini
 
 **IMPORTANT:** Make sure your `hubot-matteruser` and `mattermost-client` versions **match** the major version of your Mattermost server so the API versions will match. 
 
-For example, if you're using Mattermost server version 3.6.0 or 3.6.1, the _major version_ is "3.6", and you need version 3.5 of `hubot-matteruser` and `mattermost-client`. Neither version 3.5 or 3.7 will work, since the Mattermost server doesn't yet support API deprecation. See [releases archive](https://github.com/loafoe/hubot-matteruser/releases) for older versions. 
+For example, if you're using Mattermost server version 3.6.0 or 3.6.1, the _major version_ is "3.6", and you need version 3.6 of `hubot-matteruser` and `mattermost-client`. Neither version 3.5 or 3.7 will work, since the Mattermost server doesn't yet support API deprecation. See [releases archive](https://github.com/loafoe/hubot-matteruser/releases) for older versions. 
 
 ### 2) Install hubot-matteruser
 


### PR DESCRIPTION
Fix a typo about version requirements.

P.S. I am also a little confused about the "major version" terminology used: semver is MAJOR.MINOR.PATCH, so in 3.6.0 the major version is 3, and 6 is the minor. I would rephrase the version note as following:

> **IMPORTANT:** Make sure your `hubot-matteruser` and `mattermost-client` versions **match** the minor (`X.Y.*`) version of your Mattermost server so the API versions will match. 
> 
> For example, if you're using Mattermost server version 3.6.0 or 3.6.1, the _minor version_ is "3.6", and you need version 3.6 of `hubot-matteruser` and `mattermost-client`. Neither version 3.5 or 3.7 will work, since the Mattermost server doesn't yet support API deprecation. See [releases archive](https://github.com/loafoe/hubot-matteruser/releases) for older versions. 

If you agree with this, I can push the change, but just fixing the typo would also be awesome :)

Thanks!