### PR TITLE
Add support for message with attachments

### DIFF
--- a/src/matteruser.coffee
+++ b/src/matteruser.coffee
@@ -2,6 +2,11 @@
 
 MatterMostClient = require 'mattermost-client'
 
+class AttachmentMessage extends TextMessage
+
+    constructor: (@user, @text, @file_ids, @id) ->
+        super @user, @text, @id
+
 class Matteruser extends Adapter
 
     run: ->
@@ -177,7 +182,10 @@ class Matteruser extends Adapter
           user.mm.dm_channel_id = mmPost.channel_id
         @robot.logger.debug 'Text: ' + text
 
-        @receive new TextMessage user, text, mmPost.id
+        if mmPost.file_ids?
+            @receive new AttachmentMessage user, text, mmPost.file_ids, mmPost.id
+        else
+            @receive new TextMessage user, text, mmPost.id
         @robot.logger.debug "Message sent to hubot brain."
         return true
 


### PR DESCRIPTION
When people talking to hubot and attach some files, the file ids will be passed to hubot and then we can get the files with mattermost file APIs.
GET `https://your-mattermost-url.com/api/v3/files/{file_id}/get`
The file ids can be obtained by the following example code.
```
module.exports = (robot) ->
    robot.listen(
        (message) ->
            1
        (response) ->
            text = response.message.text + "\n"
            text += response.message.file_ids?.join(", ") or ''
            response.reply text
    )
```