### PR TITLE
changed mattermost-client dependecy to version 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "main": "./src/matteruser",
   "dependencies": {
-    "mattermost-client": "^3.7.3",
+    "mattermost-client": "^3.9.0",
     "parent-require": "^1.0.0",
     "q": "^1.4.1"
   }


### PR DESCRIPTION
Hubot-mattermost is using version 3.7.3 of mattermost client. With this change it will use version 3.9.0