### PR TITLE
User attribute "Channel_Type" added

### DIFF
--- a/src/matteruser.coffee
+++ b/src/matteruser.coffee
@@ -211,7 +211,8 @@ class Matteruser extends Adapter
         user = @robot.brain.userForId mmPost.user_id
         user.room = mmPost.channel_id
         user.room_name = msg.data.channel_display_name
-
+        user.channel_type = msg.data.channel_type
+        
         text = mmPost.message
         if msg.data.channel_type == 'D'
           if !///^@?#{@robot.name} ///i.test(text) # Direct message


### PR DESCRIPTION
I have added a new user attribute. This allows you to see directly whether it is a public channel (channel_type ='O'), a direct chat (channel_type ='D') or a group chat (channel_typte ='G').