### PR TITLE
Add missing return statement in reply function

### DIFF
--- a/src/matteruser.js
+++ b/src/matteruser.js
@@ -269,6 +269,7 @@ reply(envelope, ...strings) {
         const channel = this.client.findChannelByName(envelope.room);
         postData.channel_id = (channel ? channel.id : undefined) || envelope.room;
         this.client.customMessage(postData, postData.channel_id);
+        return;
     }
 
     // If it is, we assume they want to DM that user


### PR DESCRIPTION
I think this return statement is supposed to be here. If it's not here, you'll get an error a few lines later when it checks for `user.mm` if `user` is undefined.