### PR TITLE
Added http_proxy support

### DIFF
--- a/src/matteruser.js
+++ b/src/matteruser.js
@@ -83,6 +83,7 @@ run() {
     const mmWSSPort = process.env.MATTERMOST_WSS_PORT || '443';
     const mmHTTPPort = process.env.MATTERMOST_HTTP_PORT || null;
     const mmAccessToken = process.env.MATTERMOST_ACCESS_TOKEN || null;
+    const mmHTTPProxy = process.env.http_proxy || null;
     this.mmNoReply = process.env.MATTERMOST_REPLY === 'false';
     this.mmIgnoreUsers = (process.env.MATTERMOST_IGNORE_USERS != null ? process.env.MATTERMOST_IGNORE_USERS.split(',') : undefined) || [];
 
@@ -103,7 +104,7 @@ run() {
         process.exit(1);
     }
 
-    this.client = new MatterMostClient(mmHost, mmGroup, {wssPort: mmWSSPort, httpPort: mmHTTPPort, pingInterval: 30000});
+    this.client = new MatterMostClient(mmHost, mmGroup, {wssPort: mmWSSPort, httpPort: mmHTTPPort, pingInterval: 30000, httpProxy: mmHTTPProxy});
 
     this.client.on('open', this.open);
     this.client.on('hello', this.onHello);


### PR DESCRIPTION
mattermost-client already [supports HTTP proxies](https://github.com/loafoe/mattermost-client/blob/f4217be7c5d2e29e52e52e93a2e8c0b4ab0cfc68/src/client.js#L251). This just allows hubot-matteruser to set it.