### PR TITLE
Update user.room_name value

### DIFF
--- a/src/matteruser.js
+++ b/src/matteruser.js
@@ -345,7 +345,8 @@ message(msg) {
 
     const user = this.robot.brain.userForId(mmPost.user_id);
     user.room = mmPost.channel_id;
-    user.room_name = msg.data.channel_display_name;
+    user.room_name = msg.data.channel_name;
+    user.room_display_name = msg.data.channel_display_name;
     user.channel_type = msg.data.channel_type;
     user.root_id = mmPost.root_id;
 


### PR DESCRIPTION
"Channel display name" and "channel name" are different. They don't give the same value.

Example:

channel_display_name: `@user`
channel_name: `tay1jmy83brcbxq14hs6jmucsy__tptwwehd33bspge31scb5frtxh`

Test Environment:

hubot: 3.3.2
hubot-matteruser: 5.4.1

Closes #98 