### PR TITLE
fix(matteruser): Revert #111 DM name format

### DIFF
--- a/src/matteruser.js
+++ b/src/matteruser.js
@@ -407,6 +407,9 @@ class Matteruser extends Adapter {
 
     let text = mmPost.message;
     if (msg.data.channel_type === 'D') {
+      if (!new RegExp(`^@?${this.robot.name}`, 'i').test(text)) {
+        text = `${this.robot.name} ${text}`;
+      }
       if (!user.mm) {
         user.mm = {};
       }

--- a/tests/Matteruser_message.test.js
+++ b/tests/Matteruser_message.test.js
@@ -69,7 +69,7 @@ describe('MatterUser message', () => {
 
     expect(robot.receive).toHaveBeenCalledWith({
       done: false,
-      text: 'May the force',
+      text: 'hubot May the force',
       user: {
         channel_type: 'D',
         id: 'bfett',
@@ -103,7 +103,7 @@ describe('MatterUser message', () => {
     expect(actual).toBeInstanceOf(TextMessage);
     expect(actual).toEqual({
       done: false,
-      text: 'May the force',
+      text: 'hubot May the force',
       user: {
         channel_type: 'D',
         faction: 'jedi',
@@ -143,7 +143,7 @@ describe('MatterUser message', () => {
     expect(actual).toBeInstanceOf(TextMessage);
     expect(actual).toEqual({
       done: false,
-      origText: 'May the force',
+      origText: 'hubot May the force',
       props: {
         attachments: [
           {
@@ -159,7 +159,7 @@ describe('MatterUser message', () => {
         ]
       },
       text: [
-        'May the force',
+        'hubot May the force',
         '',
         '--',
         '',

--- a/tests/__mocks__/robot.js
+++ b/tests/__mocks__/robot.js
@@ -1,6 +1,8 @@
 const {HUBOT_SELF_USER, USER_WITH_CHANNEL, USER_WITHOUT_CHANNEL} = require("../helpers/samples");
 
-const robot = jest.fn();
+const robot = {
+  name: 'hubot'
+};
 robot.send = jest.fn();
 robot.receive = jest.fn();
 robot.on = jest.fn();


### PR DESCRIPTION
Since this update the bot does not respond to private message
instead display:

```
DEBUG No listeners executed; falling back to catch-all
```
in log