### PR TITLE
Use node14-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:14
+FROM node:14-alpine
 
 ARG hubot_owner
 ARG hubot_description
 ARG hubot_name
 
-RUN useradd -m -s /bin/bash hubot-matteruser
+RUN adduser -D -s /bin/bash hubot-matteruser
 
 RUN mkdir -p /usr/src/hubot-matteruser
 RUN chown hubot-matteruser:hubot-matteruser /usr/src/hubot-matteruser


### PR DESCRIPTION
This PR reduces the image size from 1.04GB to 211MB

```
hubot-matteruser-alpine                                       latest             7ad16f0ebfef   20 seconds ago       211MB
hubot-matteruser-debian                                       latest             7af2dccab44b   About a minute ago   1.04GB
```